### PR TITLE
Fix dev server refresh loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,5 @@ CLIENT_PORT=3020
 CORS_ORIGIN=http://localhost:3020
 API_BASE_URL=http://localhost:3021
 
-# Use "serve" if you prefer npx serve over live-server
+# Use "serve" for a static server without live reload (avoids refresh loops)
 # CLIENT_DEV_TOOL=serve

--- a/config/app.js
+++ b/config/app.js
@@ -243,6 +243,7 @@ if (APP_CONFIG.ENVIRONMENT === 'production') {
   // Development-specific settings
   APP_CONFIG.DEBUG = true;
   APP_CONFIG.LOGGING.LEVEL = 'debug';
+  APP_CONFIG.LOGGING.ENABLE_FILE = false;
   APP_CONFIG.SECURITY.RATE_LIMIT_MAX_REQUESTS = 1000;
 }
 

--- a/scripts/start-client.js
+++ b/scripts/start-client.js
@@ -20,10 +20,18 @@ if (useServe) {
   });
   child.on('exit', (code) => process.exit(code ?? 0));
 } else {
-  const child = spawn(
-    'npx',
-    ['live-server', `--port=${ports.CLIENT_PORT}`, '--entry-file=index.html', '--no-browser'],
-    { cwd: root, stdio: 'inherit', shell: true }
-  );
+  // Ignore build output, logs, and backend paths — otherwise Tailwind watch and
+  // request logging trigger live-server reload loops.
+  const ignorePaths = ['dist', 'logs', 'database', 'node_modules', '.git', 'server'];
+  const args = [
+    'live-server',
+    `--port=${ports.CLIENT_PORT}`,
+    '--entry-file=index.html',
+    '--no-browser',
+    '--no-css-inject',
+    ...ignorePaths.flatMap((p) => [`--ignore=${p}`]),
+  ];
+
+  const child = spawn('npx', args, { cwd: root, stdio: 'inherit', shell: true });
   child.on('exit', (code) => process.exit(code ?? 0));
 }

--- a/src/utils/router.js
+++ b/src/utils/router.js
@@ -26,6 +26,7 @@ export function createRouter({ onRouteChange }) {
     start() {
       if (!window.location.hash) {
         window.location.hash = '/';
+        return null;
       }
       return resolve();
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In local dev (`npm run dev`), the browser was stuck in a refresh loop when using live-server.

## Root cause

live-server watches the project root. Two paths were constantly changing and triggering reloads:

1. **`dist/styles.css`** — Tailwind `--watch` rebuilds CSS on startup and during edits
2. **`logs/app.log`** — every API request appended a log line, which triggered another reload, which made another API request, and so on

## Fix

- **live-server ignore list** — ignore `dist`, `logs`, `database`, `node_modules`, `.git`, and `server`
- **`--no-css-inject`** — avoid live-server injecting its own CSS hot-reload on top of Tailwind output
- **Disable file logging in development** — logs go to console only, so nothing under `logs/` changes during dev
- **Router startup** — avoid double route resolve when setting the initial hash

## Workaround

If you still see reload issues, set `CLIENT_DEV_TOOL=serve` in `.env` for a static server without live reload.

## Tested

- `npm run dev` on ports 3020/3021
- Multiple API requests — no repeated "Change detected" messages after initial CSS build
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1c08-3411-716f-b4d7-639baffeae6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1c08-3411-716f-b4d7-639baffeae6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

